### PR TITLE
Cert generation requires the openssl-enabled image.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   cert-gen:
-    image: alpine:latest
+    build:
+      context: .
     volumes:
       - ./certs:/app/certs
       - ./generate-certs.sh:/app/generate-certs.sh
@@ -23,7 +24,7 @@ services:
 
   fastapi:
     build:
-      dockerfile: ../fastapi.Dockerfile 
+      dockerfile: ../fastapi.Dockerfile
       context: ./app
     expose:
       - "8000" # Internal network port


### PR DESCRIPTION
Ensures docker compose up builds.