### PR TITLE
Fetch API spec before starting run.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,8 @@ services:
       - ./certs:/app/certs
     command: >
       sh -c "echo 'Running Mayhem for API tests using mTLS support...' && \
-      mapi run --key /app/certs/client.key --cert /app/certs/client.crt --cacert /app/certs/ca.crt --insecure-target --url 'https://nginx-server/' 'mapi-action-examples/fastapi' auto https://nginx-server/openapi.json ; \
+      curl -O https://nginx-server/openapi.json --key /app/certs/client.key --cert /app/certs/client.crt --cacert /app/certs/ca.crt && \
+      mapi run 'mapi-action-examples/fastapi' auto openapi.json --url 'https://nginx-server/' --key /app/certs/client.key --cert /app/certs/client.crt --cacert /app/certs/ca.crt ; \
       sleep 60"
 
   mapi-socat:


### PR DESCRIPTION
This is required for now since mTLS connections start after the spec has been validated.